### PR TITLE
[WRAITH-21] Editor Camera

### DIFF
--- a/Wraith-Editor/src/EditorLayer.h
+++ b/Wraith-Editor/src/EditorLayer.h
@@ -3,6 +3,8 @@
 #include "Wraith.h"
 #include "Panels/SceneHierarchyPanel.h"
 
+#include "Wraith/Renderer/EditorCamera.h"
+
 namespace Wraith {
 	class EditorLayer : public Layer {
 	public:
@@ -29,6 +31,8 @@ namespace Wraith {
 		Ref<Framebuffer> m_Framebuffer;
 
 		Ref<Scene> m_ActiveScene;
+
+		EditorCamera m_EditorCamera;
 
 		int m_GizmoType = -1;
 

--- a/Wraith/src/Wraith/Renderer/EditorCamera.cpp
+++ b/Wraith/src/Wraith/Renderer/EditorCamera.cpp
@@ -1,0 +1,161 @@
+#include "wpch.h"
+#include "EditorCamera.h"
+
+#include "Wraith/Core/Input.h"
+#include "Wraith/Core/KeyCodes.h"
+#include "Wraith/Core/MouseButtonCodes.h"
+
+#include <glfw/glfw3.h>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/quaternion.hpp>
+
+namespace Wraith {
+	EditorCamera::EditorCamera(float fov, float aspectRatio, float nearClip, float farClip)
+		: m_FOV(fov), m_AspectRatio(aspectRatio), m_NearClip(nearClip), m_FarClip(farClip) {
+		UpdateView();
+	}
+
+	void EditorCamera::OnUpdate(Timestep ts) {
+		const glm::vec2 mouse{ Input::GetMouseX(), Input::GetMouseY() };
+
+		if (Input::IsMouseButtonPressed(W_MOUSE_BUTTON_RIGHT)) {
+			// Mouse rotation
+			if (!m_RightMousePressedLastFrame)
+				m_InitialMousePosition = mouse;
+
+			glm::vec2 delta = (mouse - m_InitialMousePosition) * 0.003f;
+			m_InitialMousePosition = mouse;
+			MouseRotate(delta);
+			m_RightMousePressedLastFrame = true;
+
+			// WASD movement
+			auto [xSpeed, ySpeed] = PanSpeed();
+			float moveSpeed = (xSpeed * m_Distance) / 10.0f; // scale by distance like mouse pan
+			if (Input::IsKeyPressed(W_KEY_W))
+				m_FocalPoint += GetForwardDirection() * moveSpeed;
+			if (Input::IsKeyPressed(W_KEY_S))
+				m_FocalPoint -= GetForwardDirection() * moveSpeed;
+			if (Input::IsKeyPressed(W_KEY_A))
+				m_FocalPoint -= GetRightDirection() * moveSpeed;
+			if (Input::IsKeyPressed(W_KEY_D))
+				m_FocalPoint += GetRightDirection() * moveSpeed;
+
+			// Vertical
+			float verticalSpeed = (ySpeed * m_Distance) / 20.0f;
+			if (Input::IsKeyPressed(W_KEY_LEFT_SHIFT))
+				m_FocalPoint -= GetUpDirection() * verticalSpeed;
+			if (Input::IsKeyPressed(W_KEY_SPACE))
+				m_FocalPoint += GetUpDirection() * verticalSpeed;
+		}
+		else {
+			m_RightMousePressedLastFrame = false;
+		}
+
+
+		if (Input::IsMouseButtonPressed(W_MOUSE_BUTTON_MIDDLE)) {
+			if (!m_MiddleMousePressedLastFrame) {
+				m_InitialMousePosition = mouse;
+			}
+			glm::vec2 delta = (mouse - m_InitialMousePosition) * 0.003f;
+			m_InitialMousePosition = mouse;
+			MousePan(delta);
+			m_MiddleMousePressedLastFrame = true;
+		}
+		else {
+			m_MiddleMousePressedLastFrame = false;
+		}
+
+		UpdateView();
+	}
+
+
+	void EditorCamera::OnEvent(Event& e) {
+		EventDispatcher dispatcher(e);
+		dispatcher.Dispatch<MouseScrolledEvent>(W_BIND_EVENT_FN(EditorCamera::OnMouseScroll));
+	}
+
+	glm::vec3 EditorCamera::GetUpDirection() const {
+		return glm::rotate(GetOrientation(), glm::vec3(0.0f, 1.0f, 0.0f));
+	}
+
+	glm::vec3 EditorCamera::GetRightDirection() const {
+		return glm::rotate(GetOrientation(), glm::vec3(1.0f, 0.0f, 0.0f));
+	}
+
+	glm::vec3 EditorCamera::GetForwardDirection() const {
+		return glm::rotate(GetOrientation(), glm::vec3(0.0f, 0.0f, -1.0f));
+	}
+
+	glm::quat EditorCamera::GetOrientation() const {
+		return glm::quat(glm::vec3(-m_Pitch, -m_Yaw, 0.0f));
+	}
+
+	void EditorCamera::UpdateProjection() {
+		m_AspectRatio = m_ViewportWidth / m_ViewportHeight;
+		m_Projection = glm::perspective(glm::radians(m_FOV), m_AspectRatio, m_NearClip, m_FarClip);
+	}
+
+	void EditorCamera::UpdateView() {
+		m_Position = CalculatePosition();
+
+		glm::quat orientation = GetOrientation();
+		m_ViewMatrix = glm::translate(glm::mat4(1.0f), m_Position) * glm::toMat4(orientation);
+		m_ViewMatrix = glm::inverse(m_ViewMatrix);
+	}
+
+	bool EditorCamera::OnMouseScroll(MouseScrolledEvent& e) {
+		float delta = e.GetYOffset() * 0.1f;
+		MouseZoom(delta);
+		UpdateView();
+		return false;
+	}
+
+	void EditorCamera::MousePan(const glm::vec2& delta) {
+		auto [xSpeed, ySpeed] = PanSpeed();
+		m_FocalPoint += -GetRightDirection() * delta.x * xSpeed * m_Distance;
+		m_FocalPoint += GetUpDirection() * delta.y * ySpeed * m_Distance;
+	}
+
+	void EditorCamera::MouseRotate(const glm::vec2& delta) {
+		float yawSign = GetUpDirection().y < 0 ? -1.0f : 1.0f;
+		m_Yaw += yawSign * delta.x * RotationSpeed();
+		m_Pitch += delta.y * RotationSpeed();
+	}
+
+	void EditorCamera::MouseZoom(float delta) {
+		m_Distance -= delta * ZoomSpeed();
+		if (m_Distance < 1.0f) {
+			m_FocalPoint += GetForwardDirection();
+			m_Distance = 1.0f;
+		}
+	}
+
+	glm::vec3 EditorCamera::CalculatePosition() const {
+		return m_FocalPoint - GetForwardDirection() * m_Distance;
+	}
+
+	std::pair<float, float> EditorCamera::PanSpeed() const {
+		float x = std::min(m_ViewportWidth / 1000.0f, 2.4f); // Max x and y factor is 2.4
+		float xFactor = 0.0366f * (x * x) - 0.1778f * x + 0.3021f;
+
+		float y = std::min(m_ViewportHeight / 1000.0f, 2.4f);
+		float yFactor = 0.0366f * (y * y) - 0.1778f * y + 0.3021f;
+
+		return { xFactor, yFactor };
+	}
+
+	float EditorCamera::RotationSpeed() const {
+		return 0.8f;
+	}
+
+	float EditorCamera::ZoomSpeed() const {
+		float distance = m_Distance * 0.2f;
+		distance = std::max(distance, 0.0f);
+
+		float speed = distance * distance;
+		speed = std::min(speed, 100.0f); // Sets max speed to 100
+
+		return speed;
+	}
+}

--- a/Wraith/src/Wraith/Renderer/EditorCamera.h
+++ b/Wraith/src/Wraith/Renderer/EditorCamera.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "Camera.h"
+#include "Wraith/Core/Timestep.h"
+#include "Wraith/Events/Event.h"
+#include "Wraith/Events/MouseEvent.h"
+
+#include <glm/glm.hpp>
+
+namespace Wraith {
+	class EditorCamera : public Camera {
+	public:
+		EditorCamera() = default;
+		EditorCamera(float fov, float aspectRatio, float nearClip, float farClip);
+
+		void OnUpdate(Timestep ts);
+		void OnEvent(Event& e);
+
+		inline float GetDistance() const { return m_Distance; }
+		inline void SetDistance(float distance) { m_Distance = distance; }
+
+		inline void SetViewportSize(float width, float height) { m_ViewportWidth = width; m_ViewportHeight = height; UpdateProjection(); }
+
+		const glm::mat4& GetViewMatrix() const { return m_ViewMatrix; }
+		glm::mat4 GetViewProjection() const { return m_Projection * m_ViewMatrix; }
+
+		glm::vec3 GetUpDirection() const;
+		glm::vec3 GetRightDirection() const;
+		glm::vec3 GetForwardDirection() const;
+		const glm::vec3& GetPosition() const { return m_Position; }
+		glm::quat GetOrientation() const;
+
+		float GetPitch() const { return m_Pitch; }
+		float GetYaw() const { return m_Yaw; }
+	private:
+		void UpdateProjection();
+		void UpdateView();
+
+		bool OnMouseScroll(MouseScrolledEvent& e);
+
+		void MousePan(const glm::vec2& delta);
+		void MouseRotate(const glm::vec2& delta);
+		void MouseZoom(float delta);
+
+		glm::vec3 CalculatePosition() const;
+
+		std::pair<float, float> PanSpeed() const;
+		float RotationSpeed() const;
+		float ZoomSpeed() const;
+	private:
+		float m_FOV = 45.0f, m_AspectRatio = 1.778f, m_NearClip = 0.1f, m_FarClip = 1000.0f;
+
+		glm::mat4 m_ViewMatrix;
+		glm::vec3 m_Position = { 0.0f, 0.0f, 0.0f };
+		glm::vec3 m_FocalPoint = { 0.0f, 0.0f, 0.0f };
+
+		glm::vec2 m_InitialMousePosition = { 0.0f, 0.0f };
+
+		float m_Distance = 10.0f;
+		float m_Pitch = 0.0f, m_Yaw = 0.0f;
+
+		float m_ViewportWidth = 1600, m_ViewportHeight = 900;
+
+		bool m_RightMousePressedLastFrame = false;
+		bool m_MiddleMousePressedLastFrame = false;
+	};
+}

--- a/Wraith/src/Wraith/Renderer/Renderer2D.cpp
+++ b/Wraith/src/Wraith/Renderer/Renderer2D.cpp
@@ -111,10 +111,18 @@ namespace Wraith {
 		s_Data.TextureShader->Bind();
 		s_Data.TextureShader->SetMat4("u_ViewProjection", viewProjection);
 
-		s_Data.QuadIndexCount = 0;
-		s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase;
+		StartBatch();
+	}
 
-		s_Data.TextureSlotIndex = 1;
+	void Renderer2D::BeginScene(const EditorCamera& camera) {
+		W_PROFILE_FUNCTION();
+
+		glm::mat4 viewProjection = camera.GetViewProjection();
+
+		s_Data.TextureShader->Bind();
+		s_Data.TextureShader->SetMat4("u_ViewProjection", viewProjection);
+
+		StartBatch();
 	}
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera) {
@@ -123,10 +131,7 @@ namespace Wraith {
 		s_Data.TextureShader->Bind();
 		s_Data.TextureShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
 
-		s_Data.QuadIndexCount = 0;
-		s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase;
-
-		s_Data.TextureSlotIndex = 1;
+		StartBatch();
 	}
 
 	void Renderer2D::EndScene() {
@@ -152,10 +157,7 @@ namespace Wraith {
 	void Renderer2D::FlushAndReset() {
 		EndScene();
 
-		s_Data.QuadIndexCount = 0;
-		s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase;
-
-		s_Data.TextureSlotIndex = 1;
+		StartBatch();
 	}
 
 	void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color) {
@@ -406,5 +408,17 @@ namespace Wraith {
 
 	Renderer2D::Statistics Renderer2D::GetStats() {
 		return s_Data.Stats;
+	}
+
+	void Renderer2D::StartBatch() {
+		s_Data.QuadIndexCount = 0;
+		s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase;
+
+		s_Data.TextureSlotIndex = 1;
+	}
+
+	void Renderer2D::NextBatch() {
+		Flush();
+		StartBatch();
 	}
 }

--- a/Wraith/src/Wraith/Renderer/Renderer2D.h
+++ b/Wraith/src/Wraith/Renderer/Renderer2D.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Wraith/Renderer/Camera.h"
+#include "Wraith/Renderer/EditorCamera.h"
 #include "Wraith/Renderer/OrthographicCamera.h"
 
 #include "Wraith/Renderer/Texture.h"
@@ -13,6 +14,7 @@ namespace Wraith {
 		static void Shutdown();
 
 		static void BeginScene(const Camera& camera, const glm::mat4& transform);
+		static void BeginScene(const EditorCamera& camera);
 		static void BeginScene(const OrthographicCamera& camera); // TODO: Remove
 		static void EndScene();
 		static void Flush();
@@ -49,6 +51,9 @@ namespace Wraith {
 		static void ResetStats();
 		static Statistics GetStats();
 	private:
+		static void StartBatch();
+		static void NextBatch();
+
 		static void FlushAndReset();
 	};
 }

--- a/Wraith/src/Wraith/Scene/Scene.cpp
+++ b/Wraith/src/Wraith/Scene/Scene.cpp
@@ -29,7 +29,20 @@ namespace Wraith {
 		m_Registry.destroy(entity);
 	}
 
-	void Scene::OnUpdate(Timestep ts) {
+	void Scene::OnUpdateEditor(Timestep ts, EditorCamera& camera) {
+		Renderer2D::BeginScene(camera);
+
+		auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
+		for (auto entity : group) {
+			auto [transform, sprite] = group.get<TransformComponent, SpriteRendererComponent>(entity);
+
+			Renderer2D::DrawQuad(transform.GetTransform(), sprite.Color);
+		}
+
+		Renderer2D::EndScene();
+	}
+
+	void Scene::OnUpdateRuntime(Timestep ts) {
 		// Update scripts
 		{
 			m_Registry.view<NativeScriptComponent>().each([=](auto entity, auto& nsc) {

--- a/Wraith/src/Wraith/Scene/Scene.h
+++ b/Wraith/src/Wraith/Scene/Scene.h
@@ -3,6 +3,7 @@
 #include "entt.hpp"
 
 #include "Wraith/Core/Timestep.h"
+#include "Wraith/Renderer/EditorCamera.h"
 
 namespace Wraith {
 	class Entity;
@@ -15,7 +16,8 @@ namespace Wraith {
 		Entity CreateEntity(const std::string& name = std::string());
 		void DestroyEntity(Entity entity);
 
-		void OnUpdate(Timestep ts);
+		void OnUpdateEditor(Timestep ts, EditorCamera& camera);
+		void OnUpdateRuntime(Timestep ts);
 		void OnViewportResize(uint32_t width, uint32_t height);
 
 		Entity GetPrimaryCameraEntity();


### PR DESCRIPTION
Creates a movable editor camera so we no longer require a camera to be in the scene to render entities.