### PR TITLE
[WRAITH-26] Fix Fake Children in Scene Hierarchy Panel

### DIFF
--- a/Wraith-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Wraith-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -150,11 +150,6 @@ namespace Wraith {
 		}
 
 		if (opened) {
-			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth;
-			bool opened = ImGui::TreeNodeEx((void*)487321, flags, tag.c_str());
-			if (opened) {
-				ImGui::TreePop();
-			}
 			ImGui::TreePop();
 		}
 


### PR DESCRIPTION
Although I will need code like this in the coming days (maybe even today). I do not want fake children ever, and that was getting distracting while working in the SHP.