### PR TITLE
[WRAITH-40] Dragging And Dropping to Open Scenes

### DIFF
--- a/Wraith-Editor/Content/Scenes/WhiteSqaure.wscene
+++ b/Wraith-Editor/Content/Scenes/WhiteSqaure.wscene
@@ -1,0 +1,11 @@
+Scene: Untitled
+Entities:
+  - Entity: 854912389521
+    TagComponent:
+      Tag: White Square
+    TransformComponent:
+      Translation: [0, 1.29839635, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    SpriteRendererComponent:
+      Color: [1, 1, 1, 1]

--- a/Wraith-Editor/Editor/EditorLayer.h
+++ b/Wraith-Editor/Editor/EditorLayer.h
@@ -24,6 +24,7 @@ namespace Wraith {
 
 		void NewScene();
 		void OpenScene();
+		void OpenScene(const std::filesystem::path& filePath);
 		void SaveSceneAs();
 	private:
 		OrthographicCameraController m_CameraController;

--- a/Wraith-Editor/Editor/Panels/ContentBrowserPanel.h
+++ b/Wraith-Editor/Editor/Panels/ContentBrowserPanel.h
@@ -5,6 +5,9 @@
 
 #include <ImGui-Premake/imgui.h>
 
+#define IMGUI_PAYLOAD_TYPE_SCENE	"WRAITH_CONTENT_SCENE"
+#define IMGUI_PAYLOAD_TYPE_UNKNOWN	"UNKNOWN"
+
 namespace Wraith {
 	enum FileType {
 		TEXTURE = 0,
@@ -34,6 +37,7 @@ namespace Wraith {
 		FileType GetFileType(const std::filesystem::path& path);
 		ImU32 GetFileTypeColor(FileType type);
 		const char* GetFileTypeText(FileType type);
+		const char* GetImGuiTypeText(FileType type);
 
 		void OnFileSelected(const std::filesystem::path& path);
 	private:


### PR DESCRIPTION
This allows you to drag and drop to open scenes in the viewport from the content browser. I added blocking for non-scene file types and type macros for each supported file type, which is easy to extend as I need to add more.